### PR TITLE
Combine MCP and HTTP servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,13 @@ Transactions can be supplied in **multiple CSV files**. The parser understands c
   ```bash
   docker build -t financial-health-manager .
   ```
-- Run the app using a CSV file mounted at `/data`:
+- Run the HTTP server exposing port 8000:
   ```bash
-  docker run --rm -v $(pwd)/data:/data financial-health-manager \
-    python app.py /data/checking.csv /data/credit.csv
+  docker run --rm -p 8000:8000 financial-health-manager
+  ```
+- To start the MCP server instead:
+  ```bash
+  docker run --rm financial-health-manager python server.py
   ```
 
 ## Contribution Guidelines

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /app
 COPY . /app
 RUN pip install uv
 RUN uv pip install -e .[dev]
-CMD ["python", "app.py", "/data/transactions.csv"]
+EXPOSE 8000
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,44 @@ Provide one or more CSV files containing transactions:
 python app.py data/transactions.csv data/credit.csv
 ```
 
+You can pass any number of files. They will all be parsed and summarized
+together.
+
 The script prints the summary to standard output.
+
+### Running the HTTP Service
+
+Start the FastAPI server using uvicorn:
+
+```bash
+uvicorn server:app --reload
+```
+
+Send one or more CSV files using `curl`:
+
+```bash
+curl -F "files=@checking.csv" \
+     -F "files=@credit.csv" \
+     http://localhost:8000/summarize
+```
+
+You can integrate this endpoint with an LLM-based MCP client by issuing an HTTP
+request containing the transaction CSVs and processing the JSON response.
+
+### Running the MCP Server
+
+The repository includes an experimental MCP server powered by **FastMCP**.
+Launch it as a standalone process:
+
+```bash
+python server.py
+```
+
+Clients can then interact with the tool `summarize_csvs` using the MCP
+protocol. Provide a list of file paths and the server returns the same summary
+data as the HTTP endpoint.
+LLM agents that support MCP can connect to this server and call the tool to
+obtain financial summaries in JSON format.
 
 ### Running Tests
 
@@ -116,12 +153,10 @@ A basic `Dockerfile` is included for convenience. Build the image and run the co
 # Build the image
 docker build -t financial-health-manager .
 
-# Run the application
-# Mount a local directory with CSV files to /data inside the container
-# Replace transactions.csv with your file name
+# Run the HTTP server
+# Expose port 8000 and mount a local directory with CSV files if needed
 
-docker run --rm -v $(pwd)/data:/data financial-health-manager \
-  python app.py /data/transactions.csv
+docker run --rm -p 8000:8000 financial-health-manager
 ```
 
 This approach lets you run the program without installing Python locally.

--- a/app.py
+++ b/app.py
@@ -2,244 +2,33 @@
 
 from __future__ import annotations
 
-import csv
 import sys
-from collections import defaultdict
-from datetime import date, datetime
-from typing import Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Sequence
+
+from fhm import parse_csv, savings_rate, summarize
+from fhm.models import Summary
 
 
-DATE_FIELDS = {
-    "date",
-    "transaction date",
-    "posting date",
-    "settlement date",
-}
-
-CATEGORY_FIELDS = {
-    "category",
-    "description",
-    "transaction type",
-    "type",
-    "details",
-}
-
-AMOUNT_FIELDS = {"amount"}
-CREDIT_FIELDS = {"credit"}
-DEBIT_FIELDS = {"debit"}
-
-
-def _parse_date(text: str) -> date:
-    """Return a ``date`` object from a variety of common formats.
-
-    Args:
-        text: The date text to parse. Supported formats are ``YYYY-MM-DD``,
-            ``MM/DD/YYYY`` and ``MM/DD/YY``.
-
-    Returns:
-        A parsed ``date`` instance.
-
-    Raises:
-        ValueError: If the text cannot be parsed using any known format.
-    """
-
-    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y"):
-        try:
-            return datetime.strptime(text.strip(), fmt).date()
-        except ValueError:
-            continue
-    raise ValueError(f"Unsupported date format: {text}")
-
-
-def _parse_amount(text: str) -> float:
-    """Convert an amount string to ``float``.
-
-    The function removes commas and dollar signs and treats parentheses as a
-    negative sign.
-
-    Args:
-        text: Amount text from the CSV file.
-
-    Returns:
-        The numeric value as a ``float``.
-    """
-
-    cleaned = text.replace("$", "").replace(",", "").strip()
-    if not cleaned:
-        return 0.0
-    if cleaned.startswith("(") and cleaned.endswith(")"):
-        return -float(cleaned[1:-1])
-    return float(cleaned)
-
-
-def _find_index(header: Sequence[str], options: Iterable[str]) -> Optional[int]:
-    """Return the index of the first matching option in ``header``.
-
-    Args:
-        header: Sequence of header strings from the CSV.
-        options: Possible lowercase column names to search for.
-
-    Returns:
-        The index if found, otherwise ``None``.
-    """
-
-    lower = [h.lower() for h in header]
-    for name in options:
-        if name in lower:
-            return lower.index(name)
-    return None
-
-
-def _parse_csv_file(path: str) -> List[Tuple[date, str, float]]:
-    """Parse a single CSV file of transactions.
-
-    Args:
-        path: Path to the CSV file.
-
-    Returns:
-        A list of ``(date, category, amount)`` tuples.
-    """
-
-    transactions: List[Tuple[date, str, float]] = []
-    with open(path, newline="") as f:
-        reader = csv.reader(f)
-        rows = list(reader)
-
-    if not rows:
-        return transactions
-
-    header: Optional[List[str]] = None
-    try:
-        _parse_date(rows[0][0])
-    except Exception:
-        header = rows.pop(0)
-
-    if header is None:
-        for row in rows:
-            if not row:
-                continue
-            tx_date = _parse_date(row[0])
-            category = row[1]
-            amount = _parse_amount(row[2])
-            transactions.append((tx_date, category, amount))
-        return transactions
-
-    date_idx = _find_index(header, DATE_FIELDS)
-    if date_idx is None:
-        raise ValueError("Date column not found; please preprocess the file.")
-
-    amount_idx = _find_index(header, AMOUNT_FIELDS)
-    credit_idx = _find_index(header, CREDIT_FIELDS)
-    debit_idx = _find_index(header, DEBIT_FIELDS)
-    category_idx = _find_index(header, CATEGORY_FIELDS)
-
-    for row in rows:
-        if not row:
-            continue
-        tx_date = _parse_date(row[date_idx])
-        if amount_idx is not None:
-            amount = _parse_amount(row[amount_idx])
-        else:
-            credit = _parse_amount(row[credit_idx]) if credit_idx is not None else 0.0
-            debit = _parse_amount(row[debit_idx]) if debit_idx is not None else 0.0
-            amount = credit - debit
-        category = row[category_idx] if category_idx is not None else "uncategorized"
-        transactions.append((tx_date, category, amount))
-
-    return transactions
-
-
-def parse_csv(paths: Union[str, Sequence[str]]) -> List[Tuple[date, str, float]]:
-    """Parse one or more CSV files into a list of transactions.
-
-    Args:
-        paths: A single path or a sequence of paths pointing to CSV files.
-
-    Returns:
-        A combined list of ``(date, category, amount)`` tuples from all files.
-    """
-
-    if isinstance(paths, str):
-        paths = [paths]
-
-    all_tx: List[Tuple[date, str, float]] = []
-    for path in paths:
-        all_tx.extend(_parse_csv_file(path))
-    return all_tx
-
-
-def summarize(
-    transactions: Iterable[Tuple[date, str, float]],
-) -> Tuple[dict[str, float], dict[Tuple[int, int], dict[str, float]], float]:
-    """Aggregate transactions by category and month.
-
-    Args:
-        transactions: An iterable of ``(date, category, amount)`` tuples.
-
-    Returns:
-        A tuple ``(category_totals, month_data, overall_balance)`` where:
-        ``category_totals`` maps categories to totals,
-        ``month_data`` maps ``(year, month)`` to income/expense totals,
-        ``overall_balance`` is the sum of all amounts.
-    """
-
-    category_totals: dict[str, float] = defaultdict(float)
-    by_month: dict[Tuple[int, int], dict[str, float]] = defaultdict(
-        lambda: {"income": 0.0, "expenses": 0.0}
-    )
-    for tx_date, category, amount in transactions:
-        category_totals[category] += amount
-        key = (tx_date.year, tx_date.month)
-        if amount >= 0:
-            by_month[key]["income"] += amount
-        else:
-            by_month[key]["expenses"] += -amount
-    overall = sum(category_totals.values())
-    return category_totals, by_month, overall
-
-
-def savings_rate(
-    month_data: dict[Tuple[int, int], dict[str, float]],
-) -> dict[str, float]:
-    """Compute savings rate percentage for each month.
-
-    Args:
-        month_data: Output from :func:`summarize` mapping ``(year, month)`` to
-            income and expense totals.
-
-    Returns:
-        A mapping of ``YYYY-MM`` strings to savings rate percentages.
-    """
-
-    rates: dict[str, float] = {}
-    for (year, month), values in month_data.items():
-        income = values["income"]
-        expenses = values["expenses"]
-        if income > 0:
-            rate = (income - expenses) / income * 100
-            rates[f"{year}-{month:02d}"] = rate
-    return rates
-
-
-def main() -> None:
-    """Entry point for the CLI.
-
-    Expects one or more CSV file paths as command line arguments. The parsed
-    transactions are summarized and the results printed to standard output.
-    """
-
-    if len(sys.argv) < 2:
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entry point for the CLI."""
+    if argv is None:
+        argv = sys.argv[1:]
+    if len(argv) < 1:
         print("Usage: python app.py <transactions.csv> [more.csv ...]")
         raise SystemExit(1)
 
-    paths = sys.argv[1:]
-    transactions = parse_csv(paths)
+    transactions = parse_csv(argv)
     cat_totals, month_data, overall = summarize(transactions)
+    summary = Summary(
+        category_totals=cat_totals,
+        savings_rate=savings_rate(month_data),
+        overall_balance=overall,
+    )
     print("Category Totals")
-    for cat, total in cat_totals.items():
+    for cat, total in summary.category_totals.items():
         print(f"{cat:10s} {total:.2f}")
-    print(f"Overall Balance: {overall:.2f}")
-    rates = savings_rate(month_data)
+    print(f"Overall Balance: {summary.overall_balance:.2f}")
+    rates = summary.savings_rate
     if rates:
         print("\nSavings Rate by Month")
         for month, rate in sorted(rates.items()):

--- a/fhm/__init__.py
+++ b/fhm/__init__.py
@@ -1,0 +1,6 @@
+"""Financial Health Manager core utilities package."""
+
+from .core import parse_csv, savings_rate, summarize
+from .models import Summary
+
+__all__ = ["parse_csv", "savings_rate", "summarize", "Summary"]

--- a/fhm/core.py
+++ b/fhm/core.py
@@ -1,0 +1,152 @@
+"""Core finance utilities for parsing CSVs and generating summaries."""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from datetime import date, datetime
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+
+DATE_FIELDS = {
+    "date",
+    "transaction date",
+    "posting date",
+    "settlement date",
+}
+
+CATEGORY_FIELDS = {
+    "category",
+    "description",
+    "transaction type",
+    "type",
+    "details",
+}
+
+AMOUNT_FIELDS = {"amount"}
+CREDIT_FIELDS = {"credit"}
+DEBIT_FIELDS = {"debit"}
+
+
+def _parse_date(text: str) -> date:
+    """Return a ``date`` object from various common formats."""
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y"):
+        try:
+            return datetime.strptime(text.strip(), fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Unsupported date format: {text}")
+
+
+def _parse_amount(text: str) -> float:
+    """Convert an amount string to ``float``."""
+    cleaned = text.replace("$", "").replace(",", "").strip()
+    if not cleaned:
+        return 0.0
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        return -float(cleaned[1:-1])
+    return float(cleaned)
+
+
+def _find_index(header: Sequence[str], options: Iterable[str]) -> Optional[int]:
+    """Return the index of the first matching option in ``header``."""
+    lower = [h.lower() for h in header]
+    for name in options:
+        if name in lower:
+            return lower.index(name)
+    return None
+
+
+def _parse_csv_file(path: str) -> List[Tuple[date, str, float]]:
+    """Parse a single CSV file of transactions."""
+    transactions: List[Tuple[date, str, float]] = []
+    with open(path, newline="") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    if not rows:
+        return transactions
+
+    header: Optional[List[str]] = None
+    try:
+        _parse_date(rows[0][0])
+    except Exception:
+        header = rows.pop(0)
+
+    if header is None:
+        for row in rows:
+            if not row:
+                continue
+            tx_date = _parse_date(row[0])
+            category = row[1]
+            amount = _parse_amount(row[2])
+            transactions.append((tx_date, category, amount))
+        return transactions
+
+    date_idx = _find_index(header, DATE_FIELDS)
+    if date_idx is None:
+        raise ValueError("Date column not found; please preprocess the file.")
+
+    amount_idx = _find_index(header, AMOUNT_FIELDS)
+    credit_idx = _find_index(header, CREDIT_FIELDS)
+    debit_idx = _find_index(header, DEBIT_FIELDS)
+    category_idx = _find_index(header, CATEGORY_FIELDS)
+
+    for row in rows:
+        if not row:
+            continue
+        tx_date = _parse_date(row[date_idx])
+        if amount_idx is not None:
+            amount = _parse_amount(row[amount_idx])
+        else:
+            credit = _parse_amount(row[credit_idx]) if credit_idx is not None else 0.0
+            debit = _parse_amount(row[debit_idx]) if debit_idx is not None else 0.0
+            amount = credit - debit
+        category = row[category_idx] if category_idx is not None else "uncategorized"
+        transactions.append((tx_date, category, amount))
+
+    return transactions
+
+
+def parse_csv(paths: Union[str, Sequence[str]]) -> List[Tuple[date, str, float]]:
+    """Parse one or more CSV files into a list of transactions."""
+    if isinstance(paths, str):
+        paths = [paths]
+
+    all_tx: List[Tuple[date, str, float]] = []
+    for path in paths:
+        all_tx.extend(_parse_csv_file(path))
+    return all_tx
+
+
+def summarize(
+    transactions: Iterable[Tuple[date, str, float]],
+) -> Tuple[dict[str, float], dict[Tuple[int, int], dict[str, float]], float]:
+    """Aggregate transactions by category and month."""
+    category_totals: dict[str, float] = defaultdict(float)
+    by_month: dict[Tuple[int, int], dict[str, float]] = defaultdict(
+        lambda: {"income": 0.0, "expenses": 0.0}
+    )
+    for tx_date, category, amount in transactions:
+        category_totals[category] += amount
+        key = (tx_date.year, tx_date.month)
+        if amount >= 0:
+            by_month[key]["income"] += amount
+        else:
+            by_month[key]["expenses"] += -amount
+    overall = sum(category_totals.values())
+    return category_totals, by_month, overall
+
+
+def savings_rate(
+    month_data: dict[Tuple[int, int], dict[str, float]],
+) -> dict[str, float]:
+    """Compute savings rate percentage for each month."""
+    rates: dict[str, float] = {}
+    for (year, month), values in month_data.items():
+        income = values["income"]
+        expenses = values["expenses"]
+        if income > 0:
+            rate = (income - expenses) / income * 100
+            rates[f"{year}-{month:02d}"] = rate
+    return rates

--- a/fhm/models.py
+++ b/fhm/models.py
@@ -1,0 +1,13 @@
+"""Pydantic models used by Financial Health Manager."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Summary(BaseModel):
+    """Aggregated financial results."""
+
+    category_totals: dict[str, float]
+    savings_rate: dict[str, float]
+    overall_balance: float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ requires-python = ">=3.10"
 # Additional dependencies can be added as needed
 dev = [
     "ruff>=0.0.0",
-    "pytest>=0.0.0"
+    "pytest>=0.0.0",
+    "fastapi>=0.0.0",
+    "uvicorn>=0.0.0",
+    "fastmcp>=0.0.0",
 ]
 
 [tool.ruff]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,61 @@
+"""HTTP server exposing financial summary endpoints."""
+
+from typing import List
+from tempfile import NamedTemporaryFile
+import os
+
+from fastapi import FastAPI, File, UploadFile
+from fastmcp.server import FastMCP
+from fhm.models import Summary
+
+from fhm import parse_csv, savings_rate, summarize
+
+mcp_server = FastMCP("FinancialHealthManager")
+
+
+@mcp_server.tool()
+def summarize_csvs(paths: list[str]) -> Summary:
+    """Summarize one or more CSV files given by path."""
+    transactions = parse_csv(list(paths))
+    cat_totals, month_data, overall = summarize(transactions)
+    return Summary(
+        category_totals=cat_totals,
+        savings_rate=savings_rate(month_data),
+        overall_balance=overall,
+    )
+
+
+app = FastAPI(title="Financial Health Manager")
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    """Basic health check."""
+    return {"message": "Financial Health Manager"}
+
+
+@app.post("/summarize", response_model=Summary)
+async def summarize_endpoint(files: List[UploadFile] = File(...)) -> Summary:
+    """Return summary statistics for uploaded CSV files."""
+    paths = []
+    for f in files:
+        data = await f.read()
+        temp = NamedTemporaryFile(delete=False)
+        temp.write(data)
+        temp.close()
+        paths.append(temp.name)
+
+    transactions = parse_csv(paths)
+    cat_totals, month_data, overall = summarize(transactions)
+    summary = Summary(
+        category_totals=cat_totals,
+        savings_rate=savings_rate(month_data),
+        overall_balance=overall,
+    )
+    for path in paths:
+        os.unlink(path)
+    return summary
+
+
+if __name__ == "__main__":
+    mcp_server.run()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # Ensure the repository root is on the import path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from app import parse_csv, summarize, savings_rate
+from fhm import parse_csv, summarize, savings_rate
 
 
 def test_parse_csv(tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import asyncio
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from server import mcp_server
+
+
+async def call_summary(paths):
+    return await mcp_server._call_tool("summarize_csvs", {"paths": paths})
+
+
+def test_mcp_tool(tmp_path):
+    path1 = tmp_path / "a.csv"
+    path1.write_text("2024-01-01,income,100\n")
+    result = asyncio.run(call_summary([str(path1)]))
+    # call_tool returns a list of TextContent objects; parse JSON
+    import json
+
+    summary = json.loads(result[0].text)
+    assert summary["overall_balance"] == 100.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from server import app
+
+client = TestClient(app)
+
+
+def test_summarize_endpoint(tmp_path):
+    csv_text = "2024-01-01,income,100\n2024-01-02,rent,-50\n"
+    path = tmp_path / "t.csv"
+    path.write_text(csv_text)
+
+    with path.open("rb") as f:
+        files = {"files": ("t.csv", f, "text/csv")}
+        resp = client.post("/summarize", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["overall_balance"] == 50.0
+    assert data["savings_rate"]["2024-01"] == 50.0
+
+
+def test_summarize_multiple_files(tmp_path):
+    path1 = tmp_path / "a.csv"
+    path1.write_text("2024-01-01,income,100\n")
+    path2 = tmp_path / "b.csv"
+    path2.write_text("2024-01-02,rent,-60\n")
+
+    with path1.open("rb") as f1, path2.open("rb") as f2:
+        files = [
+            ("files", ("a.csv", f1, "text/csv")),
+            ("files", ("b.csv", f2, "text/csv")),
+        ]
+        resp = client.post("/summarize", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["overall_balance"] == 40.0


### PR DESCRIPTION
## Summary
- embed FastMCP tool in the main FastAPI server module
- remove the obsolete `mcp_server.py`
- adjust README and AGENTS instructions for running the MCP server
- update tests to import the MCP server from `server.py`

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c679e4470832abea60f5284bf71bf