### PR TITLE
Improve logging across core modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import sys
+import logging
 from typing import Sequence
 
 from fhm import parse_csv, savings_rate, summarize
 from fhm.models import Summary
+
+logger = logging.getLogger(__name__)
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -16,6 +19,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     if len(argv) < 1:
         print("Usage: python app.py <transactions.csv> [more.csv ...]")
         raise SystemExit(1)
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Processing %d input file(s)", len(argv))
 
     transactions = parse_csv(argv)
     cat_totals, month_data, overall = summarize(transactions)
@@ -28,11 +33,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     for cat, total in summary.category_totals.items():
         print(f"{cat:10s} {total:.2f}")
     print(f"Overall Balance: {summary.overall_balance:.2f}")
+    logger.info("Overall balance: %.2f", summary.overall_balance)
     rates = summary.savings_rate
     if rates:
         print("\nSavings Rate by Month")
         for month, rate in sorted(rates.items()):
             print(f"{month}: {rate:.1f}%")
+    logger.debug("Savings rates: %s", rates)
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@
 from typing import List
 from tempfile import NamedTemporaryFile
 import os
+import logging
 
 from fastapi import FastAPI, File, UploadFile
 from fastmcp.server import FastMCP
@@ -10,14 +11,18 @@ from fhm.models import Summary
 
 from fhm import parse_csv, savings_rate, summarize
 
+logger = logging.getLogger(__name__)
+
 mcp_server = FastMCP("FinancialHealthManager")
 
 
 @mcp_server.tool()
 def summarize_csvs(paths: list[str]) -> Summary:
     """Summarize one or more CSV files given by path."""
+    logger.info("Summarizing CSV files via MCP: %s", paths)
     transactions = parse_csv(list(paths))
     cat_totals, month_data, overall = summarize(transactions)
+    logger.debug("MCP summary generated. Overall balance: %s", overall)
     return Summary(
         category_totals=cat_totals,
         savings_rate=savings_rate(month_data),
@@ -38,6 +43,7 @@ async def root() -> dict[str, str]:
 async def summarize_endpoint(files: List[UploadFile] = File(...)) -> Summary:
     """Return summary statistics for uploaded CSV files."""
     paths = []
+    logger.info("Received %d file(s) for summarization", len(files))
     for f in files:
         data = await f.read()
         temp = NamedTemporaryFile(delete=False)
@@ -54,8 +60,11 @@ async def summarize_endpoint(files: List[UploadFile] = File(...)) -> Summary:
     )
     for path in paths:
         os.unlink(path)
+    logger.debug("Summary from endpoint computed: %s", summary.json())
     return summary
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Starting MCP server")
     mcp_server.run()


### PR DESCRIPTION
## Summary
- add `logging` to CLI, server and core utilities
- log parsed CSV structure, header indices, and transaction counts
- log overall balances and savings rate output
- log server requests and MCP tool calls

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca06830cc832ab67d3fe6a67bfbba