### PR TITLE
Improve CSV parsing models

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,8 +6,7 @@ import sys
 import logging
 from typing import Sequence
 
-from fhm import parse_csv, savings_rate, summarize
-from fhm.models import Summary
+from fhm import parse_csv, summarize
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +22,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     logger.info("Processing %d input file(s)", len(argv))
 
     transactions = parse_csv(argv)
-    cat_totals, month_data, overall = summarize(transactions)
-    summary = Summary(
-        category_totals=cat_totals,
-        savings_rate=savings_rate(month_data),
-        overall_balance=overall,
-    )
+    summary = summarize(transactions)
     print("Category Totals")
     for cat, total in summary.category_totals.items():
         print(f"{cat:10s} {total:.2f}")

--- a/fhm/__init__.py
+++ b/fhm/__init__.py
@@ -1,6 +1,6 @@
 """Financial Health Manager core utilities package."""
 
 from .core import parse_csv, savings_rate, summarize
-from .models import Summary
+from .models import Summary, Transaction
 
-__all__ = ["parse_csv", "savings_rate", "summarize", "Summary"]
+__all__ = ["parse_csv", "savings_rate", "summarize", "Transaction", "Summary"]

--- a/fhm/models.py
+++ b/fhm/models.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import date
 from pydantic import BaseModel
+
+
+class Transaction(BaseModel):
+    """Single financial transaction."""
+
+    date: date
+    category: str
+    amount: float
 
 
 class Summary(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dev = [
     "fastapi>=0.0.0",
     "uvicorn>=0.0.0",
     "fastmcp>=0.0.0",
+    "pandas>=0.0.0",
 ]
 
 [tool.ruff]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 # Ensure the repository root is on the import path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from fhm import parse_csv, summarize, savings_rate
+from fhm import parse_csv, summarize
+from fhm.models import Transaction
 
 
 def test_parse_csv(tmp_path):
@@ -17,8 +18,8 @@ def test_parse_csv(tmp_path):
     result = parse_csv(str(path))
 
     assert result == [
-        (date(2024, 1, 1), "income", 3000.0),
-        (date(2024, 1, 2), "rent", -1200.0),
+        Transaction(date=date(2024, 1, 1), category="income", amount=3000.0),
+        Transaction(date=date(2024, 1, 2), category="rent", amount=-1200.0),
     ]
 
 
@@ -33,24 +34,44 @@ def test_parse_csv_with_header_and_multiple_files(tmp_path):
     result = parse_csv([str(path1), str(path2)])
 
     assert result == [
-        (date(2024, 1, 5), "Coffee", -5.0),
-        (date(2024, 1, 6), "income", 100.0),
+        Transaction(date=date(2024, 1, 5), category="Coffee", amount=-5.0),
+        Transaction(date=date(2024, 1, 6), category="income", amount=100.0),
     ]
 
 
 def test_summarize_and_savings_rate():
     transactions = [
-        (date(2024, 1, 1), "income", 3000.0),
-        (date(2024, 1, 2), "rent", -1000.0),
-        (date(2024, 1, 3), "grocery", -500.0),
-        (date(2024, 2, 1), "income", 3500.0),
-        (date(2024, 2, 2), "rent", -1200.0),
+        Transaction(date=date(2024, 1, 1), category="income", amount=3000.0),
+        Transaction(date=date(2024, 1, 2), category="rent", amount=-1000.0),
+        Transaction(date=date(2024, 1, 3), category="grocery", amount=-500.0),
+        Transaction(date=date(2024, 2, 1), category="income", amount=3500.0),
+        Transaction(date=date(2024, 2, 2), category="rent", amount=-1200.0),
     ]
-    cat_totals, month_data, overall = summarize(transactions)
+    summary = summarize(transactions)
 
-    assert cat_totals["income"] == 6500.0
-    assert overall == pytest.approx(sum(cat_totals.values()))
+    assert summary.category_totals["income"] == 6500.0
+    assert summary.overall_balance == pytest.approx(
+        sum(summary.category_totals.values())
+    )
 
-    rates = savings_rate(month_data)
+    rates = summary.savings_rate
     assert rates["2024-01"] == pytest.approx(50.0)
     assert rates["2024-02"] == pytest.approx(((3500 - 1200) / 3500) * 100)
+
+
+def test_parse_csv_skips_bad_rows(tmp_path):
+    csv_text = (
+        "\n\nThis is not csv\nDate,Description,Amount\n"
+        "2024-01-01,income,100\n"
+        "bad,row\n"
+        "2024-01-02,rent,-50\n"
+    )
+    path = tmp_path / "messy.csv"
+    path.write_text(csv_text)
+
+    result = parse_csv(str(path))
+
+    assert result == [
+        Transaction(date=date(2024, 1, 1), category="income", amount=100.0),
+        Transaction(date=date(2024, 1, 2), category="rent", amount=-50.0),
+    ]


### PR DESCRIPTION
## Summary
- return Transaction objects from CSV parser
- return Summary model from summarize
- update CLI and server for new interfaces
- adjust tests to reflect model usage

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca5200e64832aab3567211540077b