### PR TITLE
Fix CSV parser for lines with extra commas

### DIFF
--- a/fhm/core.py
+++ b/fhm/core.py
@@ -78,6 +78,7 @@ def _parse_csv_file(path: str) -> List[Transaction]:
         skip_blank_lines=True,
         on_bad_lines="skip",
         engine="python",
+        index_col=False,
     )
 
     header = [str(col) for col in df.columns]


### PR DESCRIPTION
## Summary
- ensure pandas doesn't treat the first CSV column as the index

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb2ab4b34832aa2f2bcc336bad6ac