### PR TITLE
Fix whitespace header detection

### DIFF
--- a/fhm/core.py
+++ b/fhm/core.py
@@ -27,7 +27,7 @@ CATEGORY_FIELDS = {
     "details",
 }
 
-AMOUNT_FIELDS = {"amount"}
+AMOUNT_FIELDS = {"amount", "amount ($)"}
 CREDIT_FIELDS = {"credit"}
 DEBIT_FIELDS = {"debit"}
 
@@ -56,11 +56,14 @@ def _parse_amount(text: str) -> float:
 
 
 def _find_index(header: Sequence[str], options: Iterable[str]) -> Optional[int]:
-    """Return the index of the first matching option in ``header``."""
-    lower = [h.lower() for h in header]
+    """Return the index of the first matching option in ``header``.
+
+    Whitespace and casing differences are ignored when comparing column names.
+    """
+    normalized = [str(h).strip().lower() for h in header]
     for name in options:
-        if name in lower:
-            return lower.index(name)
+        if name in normalized:
+            return normalized.index(name)
     return None
 
 
@@ -78,6 +81,7 @@ def _parse_csv_file(path: str) -> List[Transaction]:
         skip_blank_lines=True,
         on_bad_lines="skip",
         engine="python",
+        index_col=False,
     )
 
     header = [str(col) for col in df.columns]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -72,3 +72,15 @@ def test_parse_csv_skips_bad_rows(tmp_path):
         Transaction(date=date(2024, 1, 1), category="income", amount=100.0),
         Transaction(date=date(2024, 1, 2), category="rent", amount=-50.0),
     ]
+
+
+def test_parse_csv_header_whitespace(tmp_path):
+    csv_text = "  Run Date , Description , Amount ($)\n06/12/2025,Deposit,100\n"
+    path = tmp_path / "ws.csv"
+    path.write_text(csv_text)
+
+    result = parse_csv(str(path))
+
+    assert result == [
+        Transaction(date=date(2025, 6, 12), category="Deposit", amount=100.0)
+    ]


### PR DESCRIPTION
## Summary
- support amount columns like "Amount ($)"
- ignore whitespace when searching for header columns
- add regression test for whitespace in headers

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cb2ab4b34832aa2f2bcc336bad6ac