### PR TITLE
Fix parsing files with leading metadata

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,3 +84,19 @@ def test_parse_csv_header_whitespace(tmp_path):
     assert result == [
         Transaction(date=date(2025, 6, 12), category="Deposit", amount=100.0)
     ]
+
+
+def test_parse_csv_with_leading_metadata(tmp_path):
+    """Handle files with extra lines before the header."""
+    csv_text = (
+        "History for Account X\nRun Date,06/12/2025\n"
+        "Date,Description,Amount\n06/11/2025,Deposit,200\n"
+    )
+    path = tmp_path / "fidelity.csv"
+    path.write_text(csv_text)
+
+    result = parse_csv(str(path))
+
+    assert result == [
+        Transaction(date=date(2025, 6, 11), category="Deposit", amount=200.0)
+    ]


### PR DESCRIPTION
## Summary
- handle metadata lines before the CSV header
- test parsing of a Fidelity-style CSV file

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68519709cf80832a91e2cce9068b56a8