### PR TITLE
Add server endpoints for interactive analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Along with savings rate, the following insights can help gauge your financial he
 - Months of living expenses covered by savings
 - Debt-to-income ratio
 
+### Interactive Analysis
+
+The CLI provides extra options to dive deeper into your spending:
+
+- ``--month YYYY-MM`` displays category totals for a specific month so you can
+  investigate unusual savings rates.
+- ``--yoy`` shows the average expenses for each calendar month across all
+  years, highlighting seasonal trends.
+
 ### Future Web Extension
 
 The core calculations live in a standalone module so the CLI can later be replaced or augmented by a web interface.
@@ -116,6 +125,11 @@ curl -F "files=@checking.csv" \
      http://localhost:8000/summarize
 ```
 
+Additional endpoints provide deeper analysis:
+
+- `POST /month/{YYYY-MM}` returns category totals for the specified month.
+- `POST /yoy` computes average expenses for each calendar month across years.
+
 You can integrate this endpoint with an LLM-based MCP client by issuing an HTTP
 request containing the transaction CSVs and processing the JSON response.
 
@@ -130,7 +144,10 @@ python server.py
 
 Clients can then interact with the tool `summarize_csvs` using the MCP
 protocol. Provide a list of file paths and the server returns the same summary
-data as the HTTP endpoint.
+data as the HTTP endpoint. Two additional tools are available:
+
+- `month_details` returns category totals for a specific month.
+- `yoy_trends` reports average expenses for each calendar month.
 LLM agents that support MCP can connect to this server and call the tool to
 obtain financial summaries in JSON format.
 

--- a/app.py
+++ b/app.py
@@ -2,38 +2,81 @@
 
 from __future__ import annotations
 
-import sys
+import argparse
 import logging
+import sys
 from typing import Sequence
 
-from fhm import parse_csv, summarize
+from fhm import (
+    get_month_details,
+    parse_csv,
+    summarize,
+    yoy_monthly_expenses,
+)
 
 logger = logging.getLogger(__name__)
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Return a configured argument parser."""
+
+    parser = argparse.ArgumentParser(description="Summarize financial data")
+    parser.add_argument("files", nargs="+", help="CSV files to process")
+    parser.add_argument(
+        "--month",
+        metavar="YYYY-MM",
+        help="Show category totals for a specific month",
+    )
+    parser.add_argument(
+        "--yoy",
+        action="store_true",
+        help="Display average expenses for each month across years",
+    )
+    return parser
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     """Entry point for the CLI."""
+
     if argv is None:
         argv = sys.argv[1:]
-    if len(argv) < 1:
-        print("Usage: python app.py <transactions.csv> [more.csv ...]")
-        raise SystemExit(1)
-    logging.basicConfig(level=logging.INFO)
-    logger.info("Processing %d input file(s)", len(argv))
 
-    transactions = parse_csv(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Processing %d input file(s)", len(args.files))
+
+    transactions = parse_csv(args.files)
     summary = summarize(transactions)
     print("Category Totals")
     for cat, total in summary.category_totals.items():
         print(f"{cat:10s} {total:.2f}")
     print(f"Overall Balance: {summary.overall_balance:.2f}")
     logger.info("Overall balance: %.2f", summary.overall_balance)
+
     rates = summary.savings_rate
     if rates:
         print("\nSavings Rate by Month")
         for month, rate in sorted(rates.items()):
             print(f"{month}: {rate:.1f}%")
     logger.debug("Savings rates: %s", rates)
+
+    if args.month:
+        details = get_month_details(transactions, args.month)
+        if details:
+            print(f"\nDetails for {args.month}")
+            for cat, total in sorted(details.items(), key=lambda i: -abs(i[1])):
+                print(f"{cat:10s} {total:.2f}")
+        else:
+            print(f"No transactions found for {args.month}")
+
+    if args.yoy:
+        trends = yoy_monthly_expenses(transactions)
+        if trends:
+            print("\nAverage Expenses by Month")
+            for month, avg in sorted(trends.items()):
+                print(f"{month}: {avg:.2f}")
 
 
 if __name__ == "__main__":

--- a/fhm/__init__.py
+++ b/fhm/__init__.py
@@ -1,6 +1,22 @@
 """Financial Health Manager core utilities package."""
 
-from .core import parse_csv, savings_rate, summarize
+from .core import (
+    get_month_details,
+    monthly_breakdown,
+    parse_csv,
+    savings_rate,
+    summarize,
+    yoy_monthly_expenses,
+)
 from .models import Summary, Transaction
 
-__all__ = ["parse_csv", "savings_rate", "summarize", "Transaction", "Summary"]
+__all__ = [
+    "parse_csv",
+    "savings_rate",
+    "summarize",
+    "monthly_breakdown",
+    "get_month_details",
+    "yoy_monthly_expenses",
+    "Transaction",
+    "Summary",
+]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,34 @@
+from datetime import date
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fhm import Transaction, get_month_details, yoy_monthly_expenses
+
+
+def test_get_month_details():
+    txs = [
+        Transaction(date=date(2024, 1, 1), category="income", amount=3000.0),
+        Transaction(date=date(2024, 1, 2), category="rent", amount=-1000.0),
+        Transaction(date=date(2024, 1, 3), category="groceries", amount=-200.0),
+        Transaction(date=date(2024, 2, 1), category="income", amount=500.0),
+    ]
+
+    result = get_month_details(txs, "2024-01")
+    assert result["income"] == 3000.0
+    assert result["rent"] == -1000.0
+    assert result["groceries"] == -200.0
+
+
+def test_yoy_monthly_expenses():
+    txs = [
+        Transaction(date=date(2024, 1, 1), category="income", amount=3000.0),
+        Transaction(date=date(2024, 1, 2), category="rent", amount=-1000.0),
+        Transaction(date=date(2024, 2, 3), category="rent", amount=-900.0),
+        Transaction(date=date(2025, 1, 1), category="income", amount=3500.0),
+        Transaction(date=date(2025, 1, 2), category="rent", amount=-1100.0),
+    ]
+
+    trends = yoy_monthly_expenses(txs)
+    assert trends["01"] == 1050.0
+    assert trends["02"] == 900.0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,6 +10,16 @@ async def call_summary(paths):
     return await mcp_server._call_tool("summarize_csvs", {"paths": paths})
 
 
+async def call_month_details(paths, month):
+    return await mcp_server._call_tool(
+        "month_details", {"paths": paths, "month": month}
+    )
+
+
+async def call_yoy(paths):
+    return await mcp_server._call_tool("yoy_trends", {"paths": paths})
+
+
 def test_mcp_tool(tmp_path):
     path1 = tmp_path / "a.csv"
     path1.write_text("Date,Category,Amount\n2024-01-01,income,100\n")
@@ -19,3 +29,24 @@ def test_mcp_tool(tmp_path):
 
     summary = json.loads(result[0].text)
     assert summary["overall_balance"] == 100.0
+
+
+def test_mcp_month_and_yoy(tmp_path):
+    path1 = tmp_path / "a.csv"
+    path1.write_text(
+        "Date,Category,Amount\n2024-01-01,income,100\n2024-01-02,rent,-50\n"
+    )
+    path2 = tmp_path / "b.csv"
+    path2.write_text(
+        "Date,Category,Amount\n2025-01-01,income,150\n2025-01-02,rent,-70\n"
+    )
+
+    import json
+
+    details_res = asyncio.run(call_month_details([str(path1)], "2024-01"))
+    details = json.loads(details_res[0].text)
+    assert details["rent"] == -50
+
+    yoy_res = asyncio.run(call_yoy([str(path1), str(path2)]))
+    trends = json.loads(yoy_res[0].text)
+    assert trends["01"] == 60

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,3 +39,41 @@ def test_summarize_multiple_files(tmp_path):
     assert resp.status_code == 200
     data = resp.json()
     assert data["overall_balance"] == 40.0
+
+
+def test_month_details_endpoint(tmp_path):
+    path = tmp_path / "t.csv"
+    path.write_text(
+        "Date,Category,Amount\n2024-01-01,rent,-100\n2024-01-02,income,200\n"
+    )
+
+    with path.open("rb") as f:
+        files = {"files": ("t.csv", f, "text/csv")}
+        resp = client.post("/month/2024-01", files=files)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rent"] == -100
+    assert data["income"] == 200
+
+
+def test_yoy_endpoint(tmp_path):
+    path1 = tmp_path / "a.csv"
+    path1.write_text(
+        "Date,Category,Amount\n2024-01-01,income,100\n2024-01-02,rent,-50\n"
+    )
+    path2 = tmp_path / "b.csv"
+    path2.write_text(
+        "Date,Category,Amount\n2025-01-01,income,150\n2025-01-02,rent,-70\n"
+    )
+
+    with path1.open("rb") as f1, path2.open("rb") as f2:
+        files = [
+            ("files", ("a.csv", f1, "text/csv")),
+            ("files", ("b.csv", f2, "text/csv")),
+        ]
+        resp = client.post("/yoy", files=files)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["01"] == 60


### PR DESCRIPTION
## Summary
- expose month details and YoY trend analysis through the FastAPI and MCP servers
- update documentation with new endpoints and tools
- test month details and YoY features via HTTP and MCP

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851b03b0aa4832aaa29f366233222f4